### PR TITLE
[FIX] forçando o tipo para Symbol

### DIFF
--- a/src/main/clojure/clojure/tools/build/tasks/write_pom.clj
+++ b/src/main/clojure/clojure/tools/build/tasks/write_pom.clj
@@ -39,10 +39,11 @@
 
         (seq exclusions)
         (conj [::pom/exclusions
-               (map (fn [excl]
-                      [::pom/exclusion
-                       [::pom/groupId (or (namespace excl) (name excl))]
-                       [::pom/artifactId (name excl)]])
+               (map (fn [e]
+                      (let [excl (if (not (symbol? e)) (apply symbol e) e)]
+                        [::pom/exclusion
+                        [::pom/groupId (or (namespace excl) (name excl))]
+                        [::pom/artifactId (name excl)]]))
                  exclusions)])
 
         optional


### PR DESCRIPTION
para resolver o erro que dava ao executar os comandos `[::pom/groupId (or (namespace excl) (name excl))]`. Pois por algum motivo o parametro não era do tipo Symbol